### PR TITLE
Add a function to get course history

### DIFF
--- a/studentvue/models.py
+++ b/studentvue/models.py
@@ -49,4 +49,4 @@ class Course:
         self.isAP = isAP
 
     def __repr__(self):
-        return self.name
+        return self.name+" with grade of "+self.grade

--- a/studentvue/models.py
+++ b/studentvue/models.py
@@ -44,9 +44,9 @@ class Course:
     def __init__(self, name, grade, creditsAttempted, creditsCompleted, isAP):
         self.name = name
         self.grade = grade
-        self.creditsAttempted = creditsAttempted
-        self.creditsCompleted = creditsCompleted
-        self.isAP = isAP
+        self.credits_attempted = creditsAttempted
+        self.credits_completed = creditsCompleted
+        self.is_ap = isAP
 
     def __repr__(self):
         return self.name+" with grade of "+self.grade

--- a/studentvue/models.py
+++ b/studentvue/models.py
@@ -39,3 +39,14 @@ class GradedAssignment(Assignment):
         super().__init__(name, class_name, date, assignment_id, grading_period, org_year_id)
         self.score = score
         self.max_score = max_score
+
+class Course:
+    def __init__(self, name, grade, creditsAttempted, creditsCompleted, isAP):
+        self.name = name
+        self.grade = grade
+        self.creditsAttempted = creditsAttempted
+        self.creditsCompleted = creditsCompleted
+        self.isAP = isAP
+
+    def __repr__(self):
+        return self.name

--- a/studentvue/studentvue.py
+++ b/studentvue/studentvue.py
@@ -244,10 +244,20 @@ class StudentVue:
         """
         course_history_page = BeautifulSoup(self.session.get(
             'https://{}/PXP2_CourseHistory.aspx?AGU=0'.format(self.district_domain)).text, 'html.parser')
-        yearly_course_data = course_history_page.find('table', class_='chs-course-history').div
-        print(yearly_course_data)
-        # TODO: parse data from table to proper return type
-        # TODO: test this function
+        course_data = course_history_page.find('div', class_='chs-course-history').div
+        yearly_tables = course_data.find_all('table')
+        yearly_labels = course_data.find_all('h2')
+        course_history = {}
+        for i in range(len(yearly_tables)):
+            current_table = yearly_tables[i]
+            current_courses = []
+            rows = current_table.tbody.find_all('tr')
+            del rows[0]
+            for x in rows:
+                course = list(filter(lambda index: (index != '\n'), x.strings))
+                current_courses.append(models.Course(course[0],course[1],course[2],course[3],course[0].find("AP ") != -1))
+            course_history[yearly_labels[i].contents[2].strip()] = current_courses
+        return course_history
 
     @staticmethod
     def _parse_grade_book_class_page(grade_book_page, class_name):

--- a/studentvue/studentvue.py
+++ b/studentvue/studentvue.py
@@ -237,6 +237,18 @@ class StudentVue:
 
         return self._parse_grade_book_class_page(grade_book_class_page, class_.name)
 
+    def get_course_history(self):
+        """
+        :return: Your full course history, including semester grades and number of credits earned per class.
+        :rtype: dict of a key of type studentvue.models.Course for each grade
+        """
+        course_history_page = BeautifulSoup(self.session.get(
+            'https://{}/PXP2_CourseHistory.aspx?AGU=0'.format(self.district_domain)).text, 'html.parser')
+        yearly_course_data = course_history_page.find('table', class_='chs-course-history').div
+        print(yearly_course_data)
+        # TODO: parse data from table to proper return type
+        # TODO: test this function
+
     @staticmethod
     def _parse_grade_book_class_page(grade_book_page, class_name):
         assignments = []

--- a/studentvue/studentvue.py
+++ b/studentvue/studentvue.py
@@ -244,25 +244,7 @@ class StudentVue:
         """
         course_history_page = BeautifulSoup(self.session.get(
             'https://{}/PXP2_CourseHistory.aspx?AGU=0'.format(self.district_domain)).text, 'html.parser')
-        course_data = course_history_page.find('div', class_='chs-course-history').div
-        yearly_tables = course_data.find_all('table')
-        yearly_labels = course_data.find_all('h2')
-        course_history = {}
-        for i in range(len(yearly_tables)):
-            current_table = yearly_tables[i]
-            semesters = current_table.find_all('tbody')
-            semesters_courses = []
-            sem_index = 1
-            for semester in semesters:
-                courses = semester.find_all('tr')
-                del courses[0]
-                current_courses = []
-                for x in courses:
-                    course = list(filter(lambda index: (index != '\n'), x.strings))
-                    current_courses.append(models.Course(course[0],course[1],course[2],course[3],course[0].find("AP ") != -1))
-            semesters_courses.append(current_courses)
-            course_history[yearly_labels[i].contents[2].strip()] = semesters_courses
-        return course_history
+        return self._parse_course_history_page(course_history_page)
 
     @staticmethod
     def _parse_grade_book_class_page(grade_book_page, class_name):
@@ -299,6 +281,27 @@ class StudentVue:
             'score': float(grade_book_page.find('div', class_='score').text[:-1]),
             'assignments': assignments
         }
+    @staticmethod
+    def _parse_course_history_page(page):
+        course_data = page.find('div', class_='chs-course-history').div
+        yearly_tables = course_data.find_all('table')
+        yearly_labels = course_data.find_all('h2')
+        course_history = {}
+        for i in range(len(yearly_tables)):
+            current_table = yearly_tables[i]
+            semesters = current_table.find_all('tbody')
+            semesters_courses = []
+            sem_index = 1
+            for semester in semesters:
+                courses = semester.find_all('tr')
+                del courses[0]
+                current_courses = []
+                for x in courses:
+                    course = list(filter(lambda index: (index != '\n'), x.strings))
+                    current_courses.append(models.Course(course[0],course[1],course[2],course[3],course[0].find("AP ") != -1))
+            semesters_courses.append(current_courses)
+            course_history[yearly_labels[i].contents[2].strip()] = semesters_courses
+        return course_history
 
     def get_image(self, fp):
         """

--- a/studentvue/studentvue.py
+++ b/studentvue/studentvue.py
@@ -299,7 +299,7 @@ class StudentVue:
                 for x in courses:
                     course = list(filter(lambda index: (index != '\n'), x.strings))
                     current_courses.append(models.Course(course[0],course[1],course[2],course[3],course[0].find("AP ") != -1))
-            semesters_courses.append(current_courses)
+                semesters_courses.append(current_courses)
             course_history[yearly_labels[i].contents[2].strip()] = semesters_courses
         return course_history
 

--- a/studentvue/tests/__init__.py
+++ b/studentvue/tests/__init__.py
@@ -1,1 +1,0 @@
-from .test_course_history import TestCourseHistory

--- a/studentvue/tests/__init__.py
+++ b/studentvue/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_course_history import TestCourseHistory

--- a/studentvue/tests/test_course_history.py
+++ b/studentvue/tests/test_course_history.py
@@ -1,9 +1,16 @@
 from unittest import TestCase
+import os
 
 from studentvue import StudentVue
+import studentvue.models as models
 
 class TestCourseHistory(TestCase):
-    def test_html_string:
-        sv = StudentVue()
-        # TODO: finish writing unit test
-        # TODO: create a gitignored file to put credentials in for testing
+    """A test case for the StudentVue.get_course_history function."""
+    def test_valid_courses(self):
+        if os.environ.get('TEST_USERNAME') == None:
+            print('Skipping test, no test username or password used...')
+            return
+        sv = StudentVue(os.environ.get('TEST_USERNAME'), os.environ.get('TEST_PASSWORD'), 'portal.sfusd.edu')
+        ch = sv.get_course_history()
+        key = iter(ch).__next__()
+        self.assertIsInstance(ch[key][0], models.Course)

--- a/studentvue/tests/test_course_history.py
+++ b/studentvue/tests/test_course_history.py
@@ -12,5 +12,6 @@ class TestCourseHistory(TestCase):
             return
         sv = StudentVue(os.environ.get('TEST_USERNAME'), os.environ.get('TEST_PASSWORD'), 'portal.sfusd.edu')
         ch = sv.get_course_history()
+        print(ch)
         key = iter(ch).__next__()
-        self.assertIsInstance(ch[key][0], models.Course)
+        self.assertIsInstance(ch[key][0][0], models.Course)

--- a/studentvue/tests/test_course_history.py
+++ b/studentvue/tests/test_course_history.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+from studentvue import StudentVue
+
+class TestCourseHistory(TestCase):
+    def test_html_string:
+        sv = StudentVue()
+        # TODO: finish writing unit test
+        # TODO: create a gitignored file to put credentials in for testing


### PR DESCRIPTION
Although get_schedule is sufficient for getting the current year's schedule, it would be nice to get a user's past grades. This PR adds a StudentVue.get_course_history function, which for now, returns a dictionary of format:
```python
{
  '6': [ # Grade level
    ['English 6A', 'Math 6A', ...], # 1st semester
    ['English 6B', 'Math 6B', ...] # 2nd semester
  ],
  ...
}
```
Each of the courses is of type studentvue.models.Course, which has the name, letter grade, credits attempted, and credits completed of a course, as well as if its an AP course.

Also, I added a unit testing folder to test that this function works. (If you decide to test a different way, that's fine, you can remove it.)